### PR TITLE
修改因为2020.1废除某些Icons导致的错误

### DIFF
--- a/src/main/java/com/sjhy/plugin/ui/AbstractTableGroupPanel.form
+++ b/src/main/java/com/sjhy/plugin/ui/AbstractTableGroupPanel.form
@@ -48,15 +48,11 @@
         <children>
           <component id="450d2" class="javax.swing.JButton" binding="copyGroupButton">
             <constraints/>
-            <properties>
-              <icon value="actions/copy.png"/>
-            </properties>
+            <properties/>
           </component>
           <component id="d1404" class="javax.swing.JButton" binding="deleteGroupButton">
             <constraints/>
-            <properties>
-              <icon value="actions/delete.png"/>
-            </properties>
+            <properties/>
           </component>
         </children>
       </toolbar>
@@ -76,14 +72,11 @@
           <component id="cbe8d" class="javax.swing.JButton" binding="addItemButton">
             <constraints/>
             <properties>
-              <icon value="general/add.png"/>
             </properties>
           </component>
           <component id="56e42" class="javax.swing.JButton" binding="deleteItemButton">
             <constraints/>
-            <properties>
-              <icon value="actions/delete.png"/>
-            </properties>
+            <properties/>
           </component>
         </children>
       </toolbar>

--- a/src/main/java/com/sjhy/plugin/ui/AbstractTableGroupPanel.java
+++ b/src/main/java/com/sjhy/plugin/ui/AbstractTableGroupPanel.java
@@ -1,5 +1,6 @@
 package com.sjhy.plugin.ui;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.ui.InputValidator;
 import com.intellij.openapi.ui.MessageDialogBuilder;
 import com.intellij.openapi.ui.Messages;
@@ -131,6 +132,11 @@ public abstract class AbstractTableGroupPanel<T extends AbstractGroup<E>, E> {
      */
     protected void init() {
         initFlag = false;
+        //初始化Icon
+        copyGroupButton.setIcon(AllIcons.Actions.Copy);
+        deleteGroupButton.setIcon(AllIcons.Actions.Cancel);
+        addItemButton.setIcon(AllIcons.General.Add);
+        deleteItemButton.setIcon(AllIcons.General.Remove);
         //初始化分组
         initGroup();
         //初始化列

--- a/src/main/java/com/sjhy/plugin/ui/ConfigTableDialog.form
+++ b/src/main/java/com/sjhy/plugin/ui/ConfigTableDialog.form
@@ -85,9 +85,7 @@
             <children>
               <component id="3f668" class="javax.swing.JButton" binding="addButton">
                 <constraints/>
-                <properties>
-                  <icon value="general/add.png"/>
-                </properties>
+                <properties/>
               </component>
             </children>
           </toolbar>

--- a/src/main/java/com/sjhy/plugin/ui/ConfigTableDialog.java
+++ b/src/main/java/com/sjhy/plugin/ui/ConfigTableDialog.java
@@ -1,5 +1,6 @@
 package com.sjhy.plugin.ui;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.InputValidator;
 import com.intellij.openapi.ui.Messages;
@@ -125,6 +126,7 @@ public class ConfigTableDialog extends JDialog {
      */
     private void init() {
         initFlag = false;
+        addButton.setIcon(AllIcons.General.Add);
         ColumnConfigGroup columnConfigGroup = CurrGroupUtils.getCurrColumnConfigGroup();
         // 拿到列配置信息
         columnConfigList = getInitColumn(columnConfigGroup.getElementList());

--- a/src/main/java/com/sjhy/plugin/ui/MainSetting.java
+++ b/src/main/java/com/sjhy/plugin/ui/MainSetting.java
@@ -123,7 +123,7 @@ public class MainSetting implements Configurable, Configurable.Composite {
 
         // 模板导入事件
         importBtn.addActionListener(e -> {
-            String token = Messages.showInputDialog("Token:", MsgValue.TITLE_INFO, AllIcons.General.PasswordLock, "", new InputValidator() {
+            String token = Messages.showInputDialog("Token:", MsgValue.TITLE_INFO, AllIcons.General.Settings, "", new InputValidator() {
                 @Override
                 public boolean checkInput(String inputString) {
                     return !StringUtils.isEmpty(inputString);

--- a/src/main/java/com/sjhy/plugin/ui/TemplateSettingPanel.java
+++ b/src/main/java/com/sjhy/plugin/ui/TemplateSettingPanel.java
@@ -273,7 +273,7 @@ public class TemplateSettingPanel implements Configurable {
         panel.add(comboBox);
 
         // 调试动作按钮
-        DefaultActionGroup actionGroup = new DefaultActionGroup(new AnAction(AllIcons.Debugger.ToolConsole) {
+        DefaultActionGroup actionGroup = new DefaultActionGroup(new AnAction(AllIcons.Debugger.Console) {
             @Override
             public void actionPerformed(AnActionEvent e) {
                 // 获取选中的表

--- a/src/main/java/com/sjhy/plugin/ui/TypeMapperSetting.form
+++ b/src/main/java/com/sjhy/plugin/ui/TypeMapperSetting.form
@@ -50,7 +50,6 @@
           <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <icon value="actions/copy.png"/>
           <toolTipText resource-bundle="string" key="button.type.mapper.copy.group"/>
         </properties>
       </component>
@@ -66,17 +65,13 @@
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
-            <properties>
-              <icon value="general/add.png"/>
-            </properties>
+            <properties/>
           </component>
           <component id="222d7" class="javax.swing.JButton" binding="removeButton" default-binding="true">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
-            <properties>
-              <icon value="actions/delete.png"/>
-            </properties>
+            <properties/>
           </component>
           <vspacer id="99a7d">
             <constraints>
@@ -89,9 +84,7 @@
         <constraints>
           <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties>
-          <icon value="actions/delete.png"/>
-        </properties>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/src/main/java/com/sjhy/plugin/ui/TypeMapperSetting.java
+++ b/src/main/java/com/sjhy/plugin/ui/TypeMapperSetting.java
@@ -1,6 +1,7 @@
 package com.sjhy.plugin.ui;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.ui.InputValidator;
 import com.intellij.openapi.ui.MessageDialogBuilder;
@@ -80,6 +81,12 @@ public class TypeMapperSetting implements Configurable {
 
     public TypeMapperSetting(Settings settings) {
         this.settings = settings;
+
+        this.typeMapperCopyButton.setIcon(AllIcons.Actions.Copy);
+        this.deleteButton.setIcon(AllIcons.Actions.Cancel);
+        this.addButton.setIcon(AllIcons.General.Add);
+        this.removeButton.setIcon(AllIcons.General.Remove);
+
         this.typeMapperGroupMap = CloneUtils.cloneByJson(settings.getTypeMapperGroupMap(), new TypeReference<Map<String, TypeMapperGroup>>() {});
         this.currGroupName = settings.getCurrTypeMapperGroupName();
         //添加类型


### PR DESCRIPTION
该错误会导致在2020.1及以后的版本中无法打开`File>Settings`。
相关的Issue [IDEA-235300](https://youtrack.jetbrains.com/issue/IDEA-235300).

因为2020.1之后没有PasswordLock这个Icon，我用了`AllIcons.General.Settings`做了代替，影响的文件：[src/main/java/com/sjhy/plugin/ui/MainSetting.java](https://github.com/ivyxjc/EasyCode/blob/757442f67ce4c0b404b246ae78ee09276918be21/src/main/java/com/sjhy/plugin/ui/MainSetting.java#L126)。