### PR TITLE
feat: 从实体类右键生成代码模式下，支持实体类字段【注释标签】的读取，并存放入ext数据中。

### DIFF
--- a/src/main/java/com/sjhy/plugin/dto/ColumnInfoDTO.java
+++ b/src/main/java/com/sjhy/plugin/dto/ColumnInfoDTO.java
@@ -30,7 +30,7 @@ public class ColumnInfoDTO {
         this.comment = DocCommentUtils.getComment(field.getDocComment());
         this.type = field.getType().getCanonicalText();
         this.custom = false;
-        this.ext = new HashMap<>();
+        this.ext = DocCommentUtils.getCommentTagData(field.getDocComment());
     }
 
     public ColumnInfoDTO(DasColumn column) {

--- a/src/main/java/com/sjhy/plugin/dto/TableInfoDTO.java
+++ b/src/main/java/com/sjhy/plugin/dto/TableInfoDTO.java
@@ -177,6 +177,7 @@ public class TableInfoDTO {
             columnInfo.setType(field.getType().getCanonicalText());
             columnInfo.setComment(DocCommentUtils.getComment(field.getDocComment()));
             columnInfo.setCustom(false);
+            columnInfo.setExt(DocCommentUtils.getCommentTagData(field.getDocComment()));
             tableInfo.getFullColumn().add(columnInfo);
             if (PsiClassGenerateUtils.isPkField(field)) {
                 tableInfo.getPkColumn().add(columnInfo);

--- a/src/main/java/com/sjhy/plugin/tool/DocCommentUtils.java
+++ b/src/main/java/com/sjhy/plugin/tool/DocCommentUtils.java
@@ -2,10 +2,15 @@ package com.sjhy.plugin.tool;
 
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.javadoc.PsiDocComment;
+import com.intellij.psi.javadoc.PsiDocTag;
+import com.intellij.psi.javadoc.PsiDocTagValue;
 import com.intellij.psi.javadoc.PsiDocToken;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 文档注释工具类
@@ -32,6 +37,63 @@ public class DocCommentUtils {
                 .findFirst()
                 .map(String::trim)
                 .orElse(null);
+    }
+
+    /**
+     * 获取注释标签。
+     *
+     * 注释中加入自定义的注释标签，
+     * 如：字段排序、是否在列表页显示、是否在详情页显示、使用的控件类型等，用户按自己需求定义：
+     * @fieldOrder 1
+     * @showInDetail
+     * @showInList
+     * @controlType input
+     * @customTag customTagValue
+     *
+     * customTag 作为 key，customTagValue 作为 value，存入 Map 中返回。
+     * 当注释标签值为空时，自动填充 true 值。
+     * 自动排除 "@param" "@return" 注释标签。
+     *
+     * @param docComment 文档注释
+     * @return 包含注释标签数据的Map
+     */
+    public static Map<String, Object> getCommentTagData(@Nullable PsiDocComment docComment) {
+        Map<String, Object> extData = new HashMap<>();
+        if (docComment == null) {
+            return extData;
+        }
+
+        // 忽略的注释标签
+        List<String> ignoreTagNameList = Arrays.asList("param", "return");
+
+        // 获取所有注释标签
+        PsiDocTag[] tagList = docComment.getTags();
+        for (PsiDocTag tag: tagList) {
+            String tagName = tag.getName();
+
+            // 跳过忽略的注释标签
+            if (ignoreTagNameList.contains(tagName)) {
+                continue;
+            }
+
+            // 获取注释标签数据
+            PsiElement[] dataElementList = tag.getDataElements();
+            StringBuilder sb = new StringBuilder();
+            for (PsiElement dataElement: dataElementList) {
+                sb.append(dataElement.getText());
+                if(dataElement instanceof PsiDocTagValue) {
+                    // 如果被识别为 PsiDocTagValue，getText() 会被吞吃一个空格
+                    // 比如 @testTag 1 2 3
+                    // 获取后会，值会变成："12 3"，所以多加一个空格，保持值为："1 2 3"
+                    sb.append(" ");
+                }
+            }
+            // 去除前后无效空白，若没有 tagValue，默认填充 true 值
+            String tagValue = sb.toString().trim();
+            extData.put(tagName, tagValue.length() == 0 ? true : tagValue);
+        }
+
+        return extData;
     }
 
 }


### PR DESCRIPTION
从实体类生成代码的模式下，支持读取实体类字段的【注释标签】，格式以 ‘@’ 开头。

用户可以在实体类字段中自定义添加注释标签，并在模板代码中自行使用。

比如可以加个 @controlType 指定字段使用的前端控件类型，@sort 指定字段在前端显示的排序等。

添加的新功能只是把 注释标签 加入到列的 ext 数据中，具体代码模板中如何使用 ext 数据，由用户自行控制。

使用示例如下：

```
/**
 * 客户
 */
@Entity
@Getter
@Setter
public class Client {

    /**
     * 客户名称
     * 
     * @controlType input
     * @sort 1
     * @showInDetail
     * @showInList
     * @required 客户名称不能为空
     * 
     * @testObj {"key1": "testStr", "key2": 123, "key3": true}
     * @testTag1 1 2 3 中文 4 5 6
     * @testTag2 [1, 2, 3]
     */
    private String name;

    /**
     * 手机
     * 
     * @controlType input
     * @sort 2
     * @showInDetail
     * @showInList false
     * @required 手机不能为空
     */
    private String phone;
    
}
```

列数据中将读到：
```
ColumnInfo(
    obj=null,
    name=name,
    comment=客户名称,
    type=String,
    shortType=String,
    custom=false,
    ext={
        testObj={"key1": "testStr", "key2": 123, "key3": true},
        controlType=input,
        showInList=true,
        sort=1,
        showInDetail=true,
        testTag1=1 2 3 中文 4 5 6,
        required=客户名称不能为空,
        testTag2=[1, 2, 3]
    }
)

ColumnInfo(
    obj=null,
    name=phone,
    comment=手机,
    type=String,
    shortType=String,
    custom=false,
    ext={
        controlType=input,
        showInList=false,
        sort=2,
        showInDetail=true,
        required=手机不能为空
    }
)
```

【注意事项】

1、如未提供注释标签的值，将会默认填充 true 值。如：@showInDetail，在 ext 中显示为：{ "showInDetail": true }

2、默认排除：@param @return 这两个常用方法注释标签，避免误读注释标签。

3、考虑到标签注释值的获取已支持复杂的字符串，且没想到重复标签出现的场景，所以未处理重复标签。出现多个重复标签（如：有多个 @testTag） 将会相互覆盖，只保留一个值。

【PS】

这个功能主要是想补充 ext 数据的新增方式，毕竟在 ext 数据配置页面操作不如直接在注释里写来得方便，当然，如果是从数据库生成的，那是得老老实实在界面里维护了。

