### PR TITLE
删除DEFAULT_JAVA_TYPE_LIST数组中重复的类型

### DIFF
--- a/src/main/java/com/sjhy/plugin/dict/GlobalDict.java
+++ b/src/main/java/com/sjhy/plugin/dict/GlobalDict.java
@@ -39,7 +39,6 @@ public interface GlobalDict {
             "java.lang.Short",
             "java.lang.Byte",
             "java.lang.Character",
-            "java.lang.Character",
             "java.math.BigDecimal",
             "java.math.BigInteger",
             "java.lang.Double",


### PR DESCRIPTION
`GlobalDict`的`DEFAULT_JAVA_TYPE_LIST`中有两个`java.lang.Character`